### PR TITLE
Prefect2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,8 @@ dependencies:
   - gdal = 3.3.2
   # - gdal = 3.4.0
 
-  - prefect = 0.15.13
+  - prefect = 2.2.0
+  # - prefect = 0.15.13
   - dask-core = 2022.1.1
   - distributed = 2022.1.1
 

--- a/omnisci_olio/workflow/__init__.py
+++ b/omnisci_olio/workflow/__init__.py
@@ -2,5 +2,5 @@
 OmniSci Olio workflow: high-level API client for workflow, schema API to construct table DDL
 """
 
-from .client import connect, log_info, log_warning, log_error, logi, clean_name, clean_names
+from .client import connect, log_info, log_warning, log_error, clean_name, clean_names
 from .client import connect as omnisci_task

--- a/omnisci_olio/workflow/client.py
+++ b/omnisci_olio/workflow/client.py
@@ -26,7 +26,8 @@ except:
 
 def logger():
     # return logging.getLogger('default')
-    return prefect.context.get("logger")
+    # return prefect.context.get("logger")
+    return prefect.get_run_logger()
 
 
 def log_info(**kwargs):


### PR DESCRIPTION
Updates Prefect to version 2.2 and refactors omnisci-olio/workflow/client.py to default log message levels to DEBUG (other than changing the severity level of messages, it does not affect log messaging written to the log table in the heavydb database.) This can be overridden by passing the "default_severity" switch to the OmniSciDBClient constructor or the workflow package's connect() method.